### PR TITLE
Use the released version of gftools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 absl-py==2.0.0
+afdko==4.0.1
 appdirs==1.4.4
 attrs==23.1.0
-axisregistry==0.4.3
+axisregistry==0.4.9
 babelfont==3.0.1
+beautifulsoup4==4.12.3
 blackrenderer==0.6.0
 booleanOperations==0.9.0
 Brotli==1.1.0
@@ -15,6 +17,7 @@ cffsubr==0.2.9.post1
 charset-normalizer==3.3.0
 click==8.1.7
 colorlog==6.7.0
+commandlines==0.4.1
 compreffor==0.5.5
 cryptography==42.0.4
 cu2qu==1.6.7.post2
@@ -26,21 +29,28 @@ font-v==2.1.0
 fontFeatures==1.8.0
 fontmake==3.7.1
 fontMath==0.9.3
+fontParts==0.12.1
+fontPens==0.2.4
 fonttools==4.43.1
 freetype-py==2.4.0
 fs==2.4.16
-gflanguages==0.5.7
-gftools @ git+https://github.com/googlefonts/gftools@1b710e84eb2f4e8bc860b323b568c0e8418a8eb2
+gflanguages==0.5.17
+gfsubsets==2024.2.5
+gftools==0.9.52
 gitdb==4.0.10
 GitPython==3.1.41
-glyphsets==0.6.4
+glyphsets==0.6.14
 glyphsLib==6.4.1
 h11==0.14.0
 hyperglot==0.4.5
 idna==3.4
+importlib_resources==6.4.0
 Jinja2==3.1.3
 lxml==4.9.3
+markdown-it-py==3.0.0
 MarkupSafe==2.1.3
+mdurl==0.1.2
+MutatorMath==3.0.1
 nanoemoji==0.15.1
 networkx==3.1
 ninja==1.11.1.1
@@ -49,9 +59,10 @@ openstep-plist==0.3.1
 opentype-sanitizer==9.1.0
 orjson==3.9.15
 outcome==1.2.0
+packaging==24.0
 paintcompiler==0.2.0
 picosvg==0.22.1
-Pillow==10.2.0
+pillow==10.2.0
 pip-api==0.0.30
 pngquant-cli==2.17.0.post5
 protobuf==3.20.3
@@ -61,6 +72,7 @@ pyclipper==1.3.0.post5
 pycparser==2.21
 pygit2==1.13.1
 PyGithub==2.1.1
+Pygments==2.17.2
 PyJWT==2.8.0
 PyNaCl==1.5.0
 pyparsing==3.1.1
@@ -71,6 +83,7 @@ PyYAML==6.0.1
 regex==2023.10.3
 requests==2.31.0
 resvg-cli==0.22.0.post3
+rich==13.7.1
 selenium==4.14.0
 sh==2.0.6
 six==1.16.0
@@ -79,6 +92,7 @@ skia-python==87.5
 smmap==5.0.1
 sniffio==1.3.0
 sortedcontainers==2.4.0
+soupsieve==2.5
 statmake==0.6.0
 strictyaml==1.7.3
 tabulate==0.9.0
@@ -91,6 +105,8 @@ typing_extensions==4.8.0
 ufo2ft==2.33.4
 ufoLib2==0.16.0
 ufolint==1.2.0
+ufonormalizer==0.6.1
+ufoProcessor==1.9.0
 uharfbuzz==0.37.3
 unicodedata2==15.1.0
 Unidecode==1.3.7


### PR DESCRIPTION
We were using builder2 before builder2 was officially part of gftools, and that meant we were relying on a particular git commit of gftools. This is bad and flaky, and now that gftools-with-builder2 has been released, we should pin to that version instead.